### PR TITLE
FIX: Make build compatible with gcc11

### DIFF
--- a/.SRCINFO
+++ b/.SRCINFO
@@ -1,7 +1,7 @@
 pkgbase = cloudcompare
 	pkgdesc = A 3D point cloud (and triangular mesh) processing software
 	pkgver = 2.11.3
-	pkgrel = 2
+	pkgrel = 3
 	url = http://www.danielgm.net/cc/
 	arch = i686
 	arch = x86_64
@@ -37,6 +37,7 @@ pkgbase = cloudcompare
 	source = constexpr.patch
 	source = cork.patch
 	source = pcl.patch
+	source = libE57Format-gcc11.patch
 	source = CloudCompare.desktop
 	source = ccViewer.desktop
 	sha256sums = SKIP
@@ -44,6 +45,7 @@ pkgbase = cloudcompare
 	sha256sums = 984e6186f6483534a52cb153b65dee016904eb9efdb89211c2c0042eea2417ff
 	sha256sums = 1789d726d65478857633fa4797da7c3ea4c13d90cdcc169d4197c58d2d33f123
 	sha256sums = 183f05dee316bdf7c6e9935e2a21b79b2172f61df5b0b6954bcd0d74751afc64
+	sha256sums = 7b860868a9b0cd6891b914fce8da2d84fa58be9112ffd0bed90e7b9210015f99
 	sha256sums = 14096df9cf7aca3099d5df1585d1cf669544e9b10754dce3d2507100dd7034fe
 	sha256sums = 821ac2540e1196774e26f8033946ce7b36223dae7a2a7c78f4a901b4177f68cc
 

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -9,7 +9,7 @@ name=cloudcompare
 _fragment="#tag=v2.11.3"
 pkgname=${name}
 pkgver="${_fragment###tag=v}"
-pkgrel=2
+pkgrel=3
 pkgdesc="A 3D point cloud (and triangular mesh) processing software"
 arch=('i686' 'x86_64')
 url="http://www.danielgm.net/cc/"
@@ -22,6 +22,7 @@ source=("${name}::git+https://github.com/CloudCompare/CloudCompare.git${_fragmen
         constexpr.patch
         cork.patch
         pcl.patch
+        libE57Format-gcc11.patch
         CloudCompare.desktop
         ccViewer.desktop
         )
@@ -30,6 +31,7 @@ sha256sums=('SKIP'
             '984e6186f6483534a52cb153b65dee016904eb9efdb89211c2c0042eea2417ff'
             '1789d726d65478857633fa4797da7c3ea4c13d90cdcc169d4197c58d2d33f123'
             '183f05dee316bdf7c6e9935e2a21b79b2172f61df5b0b6954bcd0d74751afc64'
+            '7b860868a9b0cd6891b914fce8da2d84fa58be9112ffd0bed90e7b9210015f99'
             '14096df9cf7aca3099d5df1585d1cf669544e9b10754dce3d2507100dd7034fe'
             '821ac2540e1196774e26f8033946ce7b36223dae7a2a7c78f4a901b4177f68cc')
 
@@ -37,6 +39,7 @@ prepare() {
   git -C "${srcdir}/${name}" submodule update --init --recursive
   git -C "${srcdir}/${name}" apply -v "${srcdir}"/{constexpr,pcl}.patch
   git -C "${srcdir}/${name}-cork" apply -v "${srcdir}"/cork.patch
+  git -C "${srcdir}/${name}/plugins/core/IO/qE57IO/extern/libE57Format" apply -v "${srcdir}"/libE57Format-gcc11.patch
 }
 
 build() {

--- a/libE57Format-gcc11.patch
+++ b/libE57Format-gcc11.patch
@@ -1,0 +1,13 @@
+diff --git a/src/E57XmlParser.cpp b/src/E57XmlParser.cpp
+index 9ba1b0d..ec32201 100644
+--- a/src/E57XmlParser.cpp
++++ b/src/E57XmlParser.cpp
+@@ -30,6 +30,8 @@
+ #include <xercesc/util/BinInputStream.hpp>
+ #include <xercesc/util/TransService.hpp>
+ 
++#include <limits>
++
+ #include "CheckedFile.h"
+ #include "E57FormatImpl.h"
+ #include "E57XmlParser.h"


### PR DESCRIPTION
This seems to fix the build with the recently released `gcc11` package. Basically only missing headers in one of the dependencies.